### PR TITLE
links a hover box-shadow to opacity .5

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -681,7 +681,7 @@ nav ul li a {
 .page .link-to-internal-pages:hover,
 .page .link-to-internal-pages:active,
 .page .link-to-internal-pages:focus {
-  box-shadow: 5px 5px 10px #000;
+  opacity: .5;
 }
 
 .is-active {


### PR DESCRIPTION
Removed box-shadow from .page .links-to-external-pages:hover,:active,:focus